### PR TITLE
Removed LOWER() from email

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Response:
 }
 ```
 
-This was a response from default `UserAuthenticator`. If your application use some custom implementation of authenticator
+This was a response from default `UserAuthenticator`. If your application uses some custom implementation of authenticator
 (e.g. `FooAuthenticator`), the authenticator can add extra parameters to the response:
 
 ```json5

--- a/src/model/Repositories/UsersRepository.php
+++ b/src/model/Repositories/UsersRepository.php
@@ -56,7 +56,7 @@ class UsersRepository extends Repository
      */
     public function getByEmail($email)
     {
-        return $this->getTable()->select('*')->where(['LOWER(email)' => strtolower($email)])->fetch();
+        return $this->getTable()->select('*')->where(['email' => $email])->fetch();
     }
 
     public function add(


### PR DESCRIPTION
Usage of the LOWER() mysql function in this case causes a very slow query execution when working with a relatively large database of users (the email index is not used). The collation of the email field is case insensitive (utf8mb4_unicode_ci), so this would give the same results. This way the email index gets used, and the query is much more faster. What do you think?

Thanks