### PR TITLE
Add event when user is enabled

### DIFF
--- a/src/Events/UserEnabledEvent.php
+++ b/src/Events/UserEnabledEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Crm\UsersModule\Events;
+
+use League\Event\AbstractEvent;
+use Nette\Database\Table\ActiveRow;
+
+class UserEnabledEvent extends AbstractEvent implements UserEventInterface
+{
+    public function __construct(private ActiveRow $user)
+    {
+    }
+
+    public function getUser(): ActiveRow
+    {
+        return $this->user;
+    }
+}

--- a/src/Models/Repositories/UsersRepository.php
+++ b/src/Models/Repositories/UsersRepository.php
@@ -9,6 +9,7 @@ use Crm\ApplicationModule\Repository;
 use Crm\ApplicationModule\Repository\AuditLogRepository;
 use Crm\UsersModule\Events\NewUserEvent;
 use Crm\UsersModule\Events\UserDisabledEvent;
+use Crm\UsersModule\Events\UserEnabledEvent;
 use Crm\UsersModule\Events\UserRegisteredEvent;
 use Crm\UsersModule\Events\UserUpdatedEvent;
 use League\Event\Emitter;
@@ -215,6 +216,8 @@ class UsersRepository extends Repository
         if ($active == 0) {
             $this->accessTokensRepository->removeAllUserTokens($user->id);
             $this->emitter->emit(new UserDisabledEvent($user));
+        } else {
+            $this->emitter->emit(new UserEnabledEvent($user));
         }
         return $user;
     }

--- a/src/UsersModule.php
+++ b/src/UsersModule.php
@@ -515,6 +515,7 @@ class UsersModule extends CrmModule
         $eventsStorage->register('user_confirmed', Events\UserConfirmedEvent::class);
         $eventsStorage->register('user_registered', Events\UserRegisteredEvent::class, true);
         $eventsStorage->register('user_disabled', Events\UserDisabledEvent::class);
+        $eventsStorage->register('user_enabled', Events\UserEnabledEvent::class);
         $eventsStorage->register('user_last_access', Events\UserLastAccessEvent::class);
         $eventsStorage->register('user_meta', Events\UserMetaEvent::class);
         $eventsStorage->register('user_reset_password', Events\UserResetPasswordEvent::class);


### PR DESCRIPTION
Purpose: we need to be able to send and email to the user when user is re-activated.

How it's done: The new type of the event UserEnabledEvent is added and is triggered during the toggleActivation() method when user `active` field is set back to true.

We need to make a backport of this change to the 2.x version, can you please create a branch `2.x` so that we could publish a version 2.12.0 with this change?

Thank you!

The event was tested in our project and works well.