### PR TITLE
Fix current_sign_in_at typo

### DIFF
--- a/src/UsersModule.php
+++ b/src/UsersModule.php
@@ -565,7 +565,7 @@ class UsersModule extends CrmModule
             'source',
             'confirmed_at',
             'email_validated_at',
-            'current_sign_it_at',
+            'current_sign_in_at',
             'created_at'
         ]);
     }


### PR DESCRIPTION
I am having trouble with segment recalculation. It is throwing this exception:
```Unable to recalculate segment [***]. Exception: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'users.current_sign_it_at' in 'field list'```

When you try to search for this string in remp2020 organisation: https://github.com/search?q=org%3Aremp2020%20current_sign_it_at&type=code, is is the only one occurrence.

I think there is a typo in current sign at field name in `UserModule::registerSegmentCriteria`.